### PR TITLE
Fix workflow push permissions

### DIFF
--- a/.github/workflows/status-rotator.yml
+++ b/.github/workflows/status-rotator.yml
@@ -8,10 +8,14 @@ on:
 jobs:
   update-status:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
+      with:
+        token: ${{ secrets.STATUS_UPDATE_TOKEN }}
 
     - name: Set up Python
       uses: actions/setup-python@v4
@@ -25,3 +29,11 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.STATUS_UPDATE_TOKEN }}
       run: python github_status_rotator.py
+
+    - name: Commit updated README.md
+      run: |
+        git config user.name "github-actions"
+        git config user.email "github-actions@github.com"
+        git add README.md
+        git commit -m "🔁 Auto-update README with new daemonic pulse" || echo "No changes to commit"
+        git push


### PR DESCRIPTION
## Summary
- ensure `STATUS_UPDATE_TOKEN` is used for checkout and pushing
- grant `contents: write` permissions so `git push` can succeed

## Testing
- `python -m py_compile github_status_rotator.py`

------
https://chatgpt.com/codex/tasks/task_e_683be73e0768832e963752d8f259baa5