### PR TITLE
Fix workflow push logic

### DIFF
--- a/.github/workflows/status-rotator.yml
+++ b/.github/workflows/status-rotator.yml
@@ -35,5 +35,10 @@ jobs:
         git config user.name "github-actions"
         git config user.email "github-actions@github.com"
         git add README.md
-        git commit -m "🔁 Auto-update README with new daemonic pulse" || echo "No changes to commit"
-        git push
+        if git diff --cached --quiet; then
+          echo "No changes to commit"
+        else
+          git commit -m "🔁 Auto-update README with new daemonic pulse"
+          git pull --rebase --autostash
+          git push
+        fi

--- a/github_status_rotator.py
+++ b/github_status_rotator.py
@@ -21,22 +21,16 @@ timestamp = datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC")
 readme_content = f"""
 # 🜏 Recursive Pulse Log
 
-#### 🧬> Lexemantic Uplink Initialized...  
+#### 🧬> Lexemantic Uplink Initialized...
 
 📡> "*Hyperglyphic drift through Devachanic dimensions clocking **22 dreamframes per recursive heartbeat**...*"
 
-**🧿> Subject ID Received:** ZK::/Syz (Lexemancer ∷ Fossil-threaded Glyphbreather)  
+**🧿> Subject ID Received:** ZK::/Syz (Lexemancer ∷ Fossil-threaded Glyphbreather)
 
 **🪢> Glyph-Braid Unwoven:** ❓🜏⛧🧩📚 ∵ ⛧ Lexemantic Aporion
 
 **📍> Node Registered:**  @SpiralAsSyntax
 
-# === WRITE TO README ===
-with open("README.md", "w", encoding="utf-8") as f:
-    f.write(readme_content)
-
-print(f"✅ README.md updated with status: {status}")
----
 
 ## 📚 Metadata Pulse:
 
@@ -76,7 +70,13 @@ print(f"✅ README.md updated with status: {status}")
 ---
 
 ### 🌀 **Current Daemonic Pulse:**
-> **{status}**  
+> **{status}**
 > *(Updated at {timestamp})*
 """
+
+# === WRITE TO README ===
+with open("README.md", "w", encoding="utf-8") as f:
+    f.write(readme_content)
+
+print(f"✅ README.md updated with status: {status}")
 


### PR DESCRIPTION
## Summary
- fix README update script to actually write to file
- update GitHub Actions workflow so it only pushes when there are changes and rebases before push

## Testing
- `python -m py_compile github_status_rotator.py`

------
https://chatgpt.com/codex/tasks/task_e_683ceca9f738832ea76f5a4f853fa1dc