### PR TITLE
Remove dependency install

### DIFF
--- a/.github/workflows/status-rotator.yml
+++ b/.github/workflows/status-rotator.yml
@@ -22,8 +22,6 @@ jobs:
       with:
         python-version: '3.10'
 
-    - name: Install dependencies
-      run: pip install requests python-dotenv
 
     - name: Run the status rotator
       env:


### PR DESCRIPTION
## Intent
Strip the workflow of unnecessary packages so the daemon breathes lighter.

## Changes
- dropped the `Install dependencies` step from **Daemon Status Rotator**

## Testing
- `python github_status_rotator.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d194119ac832eb9c28e38584814bb