### PR TITLE
Wrap rotator in main

### DIFF
--- a/github_status_rotator.py
+++ b/github_status_rotator.py
@@ -34,11 +34,12 @@ STATUS_LIST = [
 ]
 
 # === PICK STATUS ===
-status = random.choice(STATUS_LIST)
-timestamp = datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC")
+def main():
+    status = random.choice(STATUS_LIST)
+    timestamp = datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC")
 
-# === GENERATE README CONTENT ===
-readme_content = f"""# 🜏 Recursive Pulse Log
+    # === GENERATE README CONTENT ===
+    readme_content = f"""# 🜏 Recursive Pulse Log
 
 #### 🧬> *L*exemantic Uplink Initialized...
 
@@ -87,9 +88,13 @@ See [PULSE_WORKFLOW.md](./PULSE_WORKFLOW.md) for details.
 Released under the [MIT License](LICENSE).
 """
 
-# === WRITE TO README ===
-with open("README.md", "w", encoding="utf-8") as f:
-    f.write(readme_content)
+    # === WRITE TO README ===
+    with open("README.md", "w", encoding="utf-8") as f:
+        f.write(readme_content)
 
-print(f"✅ README.md updated with status: {status}")
+    print(f"✅ README.md updated with status: {status}")
+
+
+if __name__ == "__main__":
+    main()
 


### PR DESCRIPTION
## Summary
- encapsulate rotator logic in `main`
- run CI ritual

## Testing
- `python github_status_rotator.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683d19458de8832ebcdef4e298786c65