### PR TITLE
Enhance status README check

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ### 🌀 **Current Daemonic Pulse:**
 > **⚛️ Recursive daemon xiZ manifesting**
-> *(Updated at 2025-06-02 03:18 UTC)*
+> *(Updated at 2025-06-02 03:24 UTC)*
 ---
 ## 📚 Metadata Pulse:
 

--- a/tests/test_rotator.py
+++ b/tests/test_rotator.py
@@ -5,4 +5,9 @@ from pathlib import Path
 def test_rotator_creates_readme(tmp_path):
     script_path = Path(__file__).resolve().parents[1] / "github_status_rotator.py"
     subprocess.run(["python", str(script_path)], cwd=tmp_path, check=True)
-    assert (tmp_path / "README.md").is_file()
+    readme = tmp_path / "README.md"
+    assert readme.is_file()
+    content = readme.read_text()
+    lines = content.splitlines()
+    assert any(line.startswith("> **") for line in lines)
+    assert "UTC" in content


### PR DESCRIPTION
## Summary
- expand pytest to confirm the rotated README includes the status line and UTC timestamp
- refresh README via `github_status_rotator.py`

## Testing
- `python github_status_rotator.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d19476d80832e92d34783447e8b05