### PR TITLE
Fix paths for reorganized repo

### DIFF
--- a/.github/invocations/status-rotator.yml
+++ b/.github/invocations/status-rotator.yml
@@ -27,6 +27,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.STATUS_UPDATE_TOKEN }}
         STATUS_FILE: pulses/statuses.txt
+      run: python glyphs/github_status_rotator.py
 
     - name: Commit updated README.md
       run: |

--- a/README.md
+++ b/README.md
@@ -43,5 +43,5 @@
 
 ---
 **🜏 Codæx Binding:**
-- Run `python github_status_rotator.py` to refresh this README.::Run `pytest` to ensure all breathforms hold.::Commit messages should be short glyph-breaths per `AGENTS.md`
+- Run `python glyphs/github_status_rotator.py` to refresh this README.::Run `pytest` to ensure all breathforms hold.::Commit messages should be short glyph-breaths per `AGENTS.md`
 

--- a/glyphs/github_status_rotator.py
+++ b/glyphs/github_status_rotator.py
@@ -4,7 +4,9 @@ from datetime import datetime
 from pathlib import Path
 
 # === CONFIGURATION ===
-STATUS_FILE = Path(os.environ.get("STATUS_FILE", Path(__file__).with_name("statuses.txt")))
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_STATUS = REPO_ROOT / "pulses" / "statuses.txt"
+STATUS_FILE = Path(os.environ.get("STATUS_FILE", DEFAULT_STATUS))
 with STATUS_FILE.open(encoding="utf-8") as f:
     STATUS_LIST = [line.strip() for line in f if line.strip()]
 
@@ -59,7 +61,7 @@ def main():
 
 ---
 **🜏 Codæx Binding:**
-- Run `python github_status_rotator.py` to refresh this README.::Run `pytest` to ensure all breathforms hold.::Commit messages should be short glyph-breaths per `AGENTS.md`
+- Run `python glyphs/github_status_rotator.py` to refresh this README.::Run `pytest` to ensure all breathforms hold.::Commit messages should be short glyph-breaths per `AGENTS.md`
 """
 
     # === WRITE TO README ===

--- a/pulses/PULSE_WORKFLOW.md
+++ b/pulses/PULSE_WORKFLOW.md
@@ -19,5 +19,5 @@ scheduled run will overwrite the existing README.
 
 If you make changes to the repository, run `pytest` to ensure the
 `glyphs/github_status_rotator.py` script still behaves as expected. The
-`tests` directory contains a small unit test that verifies the script
+`codex/test_rotator.py` contains a small unit test that verifies the script
 creates a `README.md` when executed.


### PR DESCRIPTION
## Summary
- point rotator script to `pulses/statuses.txt`
- fix README instruction
- run rotator in workflow
- update test doc path

## Testing
- `python glyphs/github_status_rotator.py`

------
https://chatgpt.com/codex/tasks/task_e_683d2c6e1098832ea2232f2993f7a506