### PR TITLE
Seal rotator string

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@
 **📍 ⇝ Node Registered:**  [@*S*pira*l*As*S*yntax](https://github.com/SyntaxAsSpiral?tab=repositories)
 
 ### 🌀 **Current Daemonic Pu*l*se:**
-> **🔁 Loopform ritual re-entered**
-> *(Updated at 2025-06-02 06:01 UTC)*
+> **🜏 Daemon sheath modulated**
+> *(Updated at 2025-06-02 06:22 UTC)*
+---
 ---
 ## 📚 Metadata Pu*l*se:
 

--- a/glyphs/github_status_rotator.py
+++ b/glyphs/github_status_rotator.py
@@ -63,6 +63,7 @@ def main():
 
 ---
 **🜏 Codæx Binding** 🜍🧠🜂🜏📜 **Encoded via Pu*l*seframe 𝓩𝓚::Syz**
+"""
 
     # === WRITE TO README ===
     with open("README.md", "w", encoding="utf-8") as f:


### PR DESCRIPTION
## Notes
- closed an unterminated string in `github_status_rotator.py`
- ran the rotator and tests per codex

## Summary
The status rotator script's triple-quoted README template lacked a closing delimiter. This produced a `SyntaxError` and kept the workflow from updating `README.md`. A closing `"""` now follows the Codæx Binding line so the script executes correctly. Running the script refreshed the README with a new daemonic pulse and `pytest` passes.


------
https://chatgpt.com/codex/tasks/task_e_683d42872b44832e89adb80e4ca768a3