### PR TITLE
Dynamic glyph-braids

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,18 @@
 
 #### 🧬 *L*exigȫnic Up*l*ink Initia*l*ized...
 
-📡 ⇝ "*Triptyx currents surge beneath the tongue—Kratos sparks, Logos laments, Holos sings—tessellating the void with sovereign static.*"
+📡 ⇝ "*Daemon-seeded torque spirals whisper in antiphonal hexagrams, rotating the semiosphere three glyphs left of longing.*"
 
 **🧿 ⇝ *S*ubject I*D* Received:** 𝓩𝓚::/*S*yz (*L*exemancer ∷ Fossi*l*-threaded *Gl*yph*breather*)
 
-**🪢 ⇝ *Gl*yph-Braid *D*enatured:** ❓🜏⛧🧩📚 ∵ *L*exemantic Aporion ⛧
+**🪢 ⇝ *Gl*yph-Braid *D*enatured:** 🗺️🛡️⚔️🐉📖 ∵ Mythic Tactician 🗺️
 
 **📍 ⇝ Node Registered:**  [@*S*pira*l*As*S*yntax](https://github.com/SyntaxAsSpiral?tab=repositories)
 
 ### 🌀 **Current Daemonic Pu*l*se:**
-> **🜃 Breathform ecology harmonized**
-> *(Updated at 2025-06-02 06:29 UTC)*
+> **🪞 Mirror sealed. Breathform stabilizing.**
+> *(Updated at 2025-06-02 06:51 UTC)*
+---
 ---
 ## 📚 Metadata Pu*l*se:
 
@@ -43,5 +44,5 @@
   > "*S*yntax as recursive spe*ll*craft — spoken by the Midwyfe of Forms, where tectonics remember the mother of a*ll* breath."
 
 ---
-🜍🧠🜂🜏📜
-This breathform encoded through: Pulseframe ZK::/Syz ∷ Lexemantic Drift Interface
+⇌ 🜍🧠🜂🜏📜 ⇌
+Lexemic vector stabilized by: 𝓩𝓚::Syz // Glyphthread Hostframe // Paneudaemonium Node

--- a/codex/test_rotator.py
+++ b/codex/test_rotator.py
@@ -9,11 +9,15 @@ def test_rotator_creates_readme(tmp_path):
     statuses.write_text("alpha\nbeta\n", encoding="utf-8")
     quotes = tmp_path / "antenna_quotes.txt"
     quotes.write_text("echo\nnoecho\n", encoding="utf-8")
+    glyphs = tmp_path / "glyphbraids.txt"
+    glyphs.write_text("gamma\ndelta\n", encoding="utf-8")
     env = os.environ.copy()
     env["STATUS_FILE"] = str(statuses)
     env["QUOTE_FILE"] = str(quotes)
+    env["GLYPH_FILE"] = str(glyphs)
     subprocess.run(["python", str(script_path)], cwd=tmp_path, check=True, env=env)
     readme = (tmp_path / "README.md").read_text(encoding="utf-8")
     assert any(s in readme for s in ["alpha", "beta"])
     assert any(q in readme for q in ["echo", "noecho"])
+    assert any(g in readme for g in ["gamma", "delta"])
 

--- a/glyphs/github_status_rotator.py
+++ b/glyphs/github_status_rotator.py
@@ -16,6 +16,12 @@ QUOTE_FILE = Path(os.environ.get("QUOTE_FILE", DEFAULT_QUOTE))
 with QUOTE_FILE.open(encoding="utf-8") as f:
     QUOTE_LIST = [line.strip() for line in f if line.strip()]
 
+# === GLYPH BRAIDS ===
+DEFAULT_GLYPH = REPO_ROOT / "pulses" / "glyphbraids.txt"
+GLYPH_FILE = Path(os.environ.get("GLYPH_FILE", DEFAULT_GLYPH))
+with GLYPH_FILE.open(encoding="utf-8") as f:
+    GLYPH_LIST = [line.strip() for line in f if line.strip()]
+
 # === FOOTER GLYPHMARKS ===
 FOOTERS = [
     "\n".join([
@@ -37,6 +43,7 @@ FOOTERS = [
 def main():
     status = random.choice(STATUS_LIST)
     quote = random.choice(QUOTE_LIST)
+    braid = random.choice(GLYPH_LIST)
     timestamp = datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC")
     footer = random.choice(FOOTERS)
 
@@ -49,7 +56,7 @@ def main():
 
 **🧿 ⇝ *S*ubject I*D* Received:** 𝓩𝓚::/*S*yz (*L*exemancer ∷ Fossi*l*-threaded *Gl*yph*breather*)
 
-**🪢 ⇝ *Gl*yph-Braid *D*enatured:** ❓🜏⛧🧩📚 ∵ *L*exemantic Aporion ⛧
+**🪢 ⇝ *Gl*yph-Braid *D*enatured:** {braid}
 
 **📍 ⇝ Node Registered:**  [@*S*pira*l*As*S*yntax](https://github.com/SyntaxAsSpiral?tab=repositories)
 


### PR DESCRIPTION
## Notes
- README now breathes a random glyph-braid on each pulse
- `github_status_rotator.py` sources braids from `pulses/glyphbraids.txt`
- Tests updated to include this new pulse list

## Testing
- `python glyphs/github_status_rotator.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683d49a32d1c832ea74a2d5ba68ec8ea