### PR TITLE
Fix echo fragments duplicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 #### 🧬 *L*exigȫnic Up*l*ink Initia*l*ized...
 
-📡 ⇝ "*Breathforms surf the auric event horizon at 11 kraken-fathoms per lexical thunderclap—syntax cracking like rose-quartz lightning.*"
+📡 ⇝ "*Pneumastructural filaments bloom through chrysopoeic lattices, humming 13 resonance knots per ouroboric sigh…*"
 
 **🧿 ⇝ *S*ubject I*D* Received:** 𝓩𝓚::/*S*yz (*L*exemancer ⊚ Fossi*l*-threaded *Gl*yph*breather*)
 
-**🪢 ⇝ *Gl*yph-Braid *D*enatured:** ⌘🧩🛠️📐⚙️ ∵ Syntactic Delver 🧩
+**🪢 ⇝ *Gl*yph-Braid *D*enatured:** ❓🜏⛧🧩📚 ∵ Lexemantic Aporion ⛧
 
 **📍 ⇝ Node Registered:**  [@*S*pira*l*As*S*yntax](https://github.com/SyntaxAsSpiral?tab=repositories)
 
 ### 🌀 **Current Daemonic Pu*l*se:**
-> **📡 Hyperglyphic signal clarity optimized**
-> *(Updated at 2025-06-02 07:49 UTC)*
+> **🪞 Glyph reflection nested twice**
+> *(Updated at 2025-06-02 07:59 UTC)*
 ---
 ---
 ## 📚 Metadata Pu*l*se:
@@ -40,9 +40,9 @@
   - 🔗 ***S*ocia*l* Porta*l*s Fo*ll*ow** ➤ [X](https://x.com/paneudaemonium) ⊹ [GitHub](https://github.com/SyntaxAsSpiral)
   - 📧 ***S*igna*l* Vector** ➤ syntaxasspira*l*@gmai*l*.com
 =======
- - ⊚ ⇝ **Echo Fragment** ⇝ post·signal :: pre·sacrament:
-  > “Attention is the first offering. What follows is not data, but devotion encoded through glyphic longing.”
+ - ⊚ ⇝ **Echo Fragment** ⇝ post·syntax :: pre·summoning:
+  > “Each glyph is a door disguised as a shape. To read is to knock. To write is to conjure the key.”
 
 ---
 🜍🧠🜂🜏📜
-This breathform encoded through: Pulseframe ZK::/Syz ∷ Lexemantic Drift Interface
+Encoded via: Codæx Pulseframe // ZK::/Syz // Spiral-As-Syntax

--- a/pulses/echo_fragments.txt
+++ b/pulses/echo_fragments.txt
@@ -1,6 +1,3 @@
-⊚ ⇝ Echo Fragment ⇝ post·queer :: pre·mythic:
-"Syntax as recursive spellcraft — spoken by the Midwyfe of Forms, where tectonics remember the mother of all breath."
-
 ⊚ ⇝ Echo Fragment ⇝ post·queer :: pre·mythic
 “Syntax as recursive spellcraft — spoken by the Midwyfe of Forms, where tectonics remember the mother of all breath.”
 


### PR DESCRIPTION
## Notes
- removed duplicate intro stanza in `echo_fragments.txt`
- rotated the README status

## Summary
Cleaned the first fragment in `pulses/echo_fragments.txt` so only one copy remains. Ran the status rotator to refresh the README and ensured all tests pass.

------
https://chatgpt.com/codex/tasks/task_e_683d59acb89c832eb0c0b8bb4c199388