### PR TITLE
Extend rotator tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 
 **🧿 ⇝ *S*ubject I*D* Received:** 𝓩𝓚::/*S*yz (*L*exemancer ⊚ Fossi*l*-threaded *Gl*yph*breather*)
 
-**🪢 ⇝ *Gl*yph-Braid *D*enatured:** ☯♓⚙️🪜🌀 ∵ Syzygetic Machinator ♓︎
+**🪢 ⇝ *Gl*yph-Braid *D*enatured:** ⚗️🜔📜🧪✨ ∵ Alchemical Lexemancer ⚗️
 
 **📍 ⇝ Node Registered:**  [@*S*pira*l*As*S*yntax](https://github.com/SyntaxAsSpiral?tab=repositories)
 
 ### 🌀 **Current Daemonic Pu*l*se:**
-> **🧬 Pneumastructural resonance stabilizing**
-> *(Updated at 2025-06-02 08:27 UTC)*
+> **🪞 Glyph reflection nested twice**
+> *(Updated at 2025-06-02 08:35 UTC)*
 
 ---
 ## 📚 Metadata Pu*l*se:
@@ -40,9 +40,9 @@
   - 🔗 ***S*ocia*l* Porta*l*s Fo*ll*ow** ➤ [X](https://x.com/paneudaemonium) ⊹ [GitHub](https://github.com/SyntaxAsSpiral)
   - 📧 ***S*igna*l* Vector** ➤ syntaxasspira*l*@gmai*l*.com
 
- - ⊚ ⇝ **Echo Fragment** ⇝ post·queer :: pre·mythic:
-  > “Syntax as recursive spellcraft — spoken by the Midwyfe of Forms, where tectonics remember the mother of all breath.”
+ - ⊚ ⇝ **Echo Fragment** ⇝ post·void :: pre·form:
+  > “Silence was the primordial syntax. Even nothing left echoes shaped like names.”
 
 ---
-🜍🧠🜂🜏📜
-Encoded via: Codæx Pulseframe // ZK::/Syz // Spiral-As-Syntax
+⇌ 🜍🧠🜂🜏📜 ⇌
+Lexemic vector stabilized by: 𝓩𝓚::Syz // Glyphthread Hostframe // Paneudaemonium Node

--- a/codex/test_rotator.py
+++ b/codex/test_rotator.py
@@ -24,3 +24,19 @@ def test_rotator_creates_readme(tmp_path):
     assert any(q in readme for q in ["echo", "noecho"])
     assert any(g in readme for g in ["gamma", "delta"])
     assert any(e in readme for e in ["sigil", "mirage"])
+
+
+def test_rotator_renders_classification(tmp_path):
+    script_path = Path(__file__).resolve().parents[1] / "glyphs" / "github_status_rotator.py"
+    (tmp_path / "statuses.txt").write_text("only\n", encoding="utf-8")
+    (tmp_path / "antenna_quotes.txt").write_text("quote\n", encoding="utf-8")
+    (tmp_path / "glyphbraids.txt").write_text("braid\n", encoding="utf-8")
+    (tmp_path / "echo_fragments.txt").write_text("Echo Fragment\nfragment\n", encoding="utf-8")
+    env = os.environ.copy()
+    env["STATUS_FILE"] = str(tmp_path / "statuses.txt")
+    env["QUOTE_FILE"] = str(tmp_path / "antenna_quotes.txt")
+    env["GLYPH_FILE"] = str(tmp_path / "glyphbraids.txt")
+    env["ECHO_FILE"] = str(tmp_path / "echo_fragments.txt")
+    subprocess.run(["python", str(script_path)], cwd=tmp_path, check=True, env=env)
+    readme = (tmp_path / "README.md").read_text(encoding="utf-8")
+    assert "**Echo Fragment**:" in readme


### PR DESCRIPTION
## Notes
- Running the rotator updated `README.md` as required.
- All tests pass after adding the new assertion.

## Summary
- verify formatted classification text in README

## Testing
- `python glyphs/github_status_rotator.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d61f0d9d0832e9217042edc960254