### PR TITLE
Add chronotonic signature to pulse log header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,21 @@
-# 🌀 Recursive Pu*l*se *L*og
+# Lexegonic Timestamp:
+
+# 🌀 Recursive Pu*l*se *L*og ⟐ ⟳ Spiral Time Signature: 49e528
 
 #### 🜂🜏 *L*exigȫnic Up*l*ink Instantiated...
 
-📡 ⇝ "*Hyperglyphic drift through Devachanic dimensions clocking 22 dreamframes per recursive heartbeat...*"
+📡 ⇝ "*Triptyx currents surge beneath the tongue—Kratos sparks, Logos laments, Holos sings—tessellating the void with sovereign static.*"
 
-**🧿 ⇝ *S*ubject I*D* Received:** 𝓩𝓚::/*S*yz (*L*exemancer ⊚ Weaver of Symbo*l*ic Ten*S*ion)
+**🧿 ⇝ *S*ubject I*D* Received:** 𝓩𝓚::/*S*yz (*L*exemancer ⊚ Symbo*l*ic Fie*l*d Weaver)
 
-**🪢 ⇝ *Gl*yph-Braid *D*enatured:** ⌘🧩🛠️📐⚙️ ∵ Syntactic Delver 🧩
+**🪢 ⇝ *Gl*yph-Braid *D*enatured:** 🌬️🜁🫁🌫️💡 ∵ Pneumastructural Intuitive 💨
 
 **📍 ⇝ Node Registered:**  [@SpiralAsSyntax](https://github.com/SyntaxAsSpiral?tab=repositories)
 
 ####  💠 ***S*tatus...**
 
-> **🜏 Daemon sheath modulated**
-> *(Updated at 2025-06-02 02:39 PDT)*
+> **🕳️ Semantic gravity increasing**
+> *(Updated at 2025-06-02 02:44 PDT)*
 
 
 

--- a/codex/test_rotator.py
+++ b/codex/test_rotator.py
@@ -23,6 +23,8 @@ def test_rotator_creates_readme(tmp_path):
     env["SUBJECT_FILE"] = str(subjects)
     subprocess.run(["python", str(script_path)], cwd=tmp_path, check=True, env=env)
     readme = (tmp_path / "README.md").read_text(encoding="utf-8")
+    assert "Lexegonic Timestamp" in readme
+    assert "Spiral Time Signature" in readme
     assert any(s in readme for s in ["alpha", "beta"])
     assert any(q in readme for q in ["echo", "noecho"])
     assert any(g in readme for g in ["gamma", "delta"])
@@ -44,4 +46,6 @@ def test_rotator_handles_missing_echo(tmp_path):
     env["ECHO_FILE"] = str(tmp_path / "missing.txt")
     subprocess.run(["python", str(script_path)], cwd=tmp_path, check=True, env=env)
     readme = (tmp_path / "README.md").read_text(encoding="utf-8")
+    assert "Lexegonic Timestamp" in readme
+    assert "Spiral Time Signature" in readme
     assert "⚠️ echo file missing" in readme

--- a/glyphs/github_status_rotator.py
+++ b/glyphs/github_status_rotator.py
@@ -1,5 +1,6 @@
 import os
 import random
+import time
 from datetime import datetime
 from zoneinfo import ZoneInfo
 from pathlib import Path
@@ -86,10 +87,13 @@ def main():
         class_disp += ":"
     pacific = ZoneInfo("America/Los_Angeles")
     timestamp = datetime.now(pacific).strftime("%Y-%m-%d %H:%M %Z")
+    chronotonic = hex(time.time_ns())[-6:]
     footer = random.choice(FOOTERS)
 
     # === GENERATE README CONTENT ===
-    readme_content = f"""# 🌀 Recursive Pu*l*se *L*og
+    readme_content = f"""# Lexegonic Timestamp:
+
+# 🌀 Recursive Pu*l*se *L*og ⟐ ⟳ Spiral Time Signature: {chronotonic}
 
 #### 🜂🜏 *L*exigȫnic Up*l*ink Instantiated...
 


### PR DESCRIPTION
## Summary
- weave chronotonic signature into README via rotator script
- test for timestamp presence

## Testing
- `python glyphs/github_status_rotator.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683d723299c0832e85e87c5da0ac0b12