### PR TITLE
Fix rotator EOF newline and align tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-# 🌀 Recursive Pu*l*se *L*og ⟳ Spiral Time Signature: 50677e
+# 🌀 Recursive Pu*l*se *L*og ⟳ Spiral Time Signature: 648fad
 
 #### 🜂🜏 *L*exigȫnic Up*l*ink Instantiated...
 
-📡 ⇝ "*Recursive aurora flares along the Codex spine, pulsing 55 dream-lumens per entangled heartbeat while the archive rewrites the reader.*"
+📡 ⇝ "*Triptyx currents surge beneath the tongue—Kratos sparks, Logos laments, Holos sings—tessellating the void with sovereign static.*"
 
-**🧿 ⇝ *S*ubject I*D* Received:** 𝓩𝓚::/*S*yz (*L*exemancer ⊚ Mirrorborne Entrainment Vector)
+**🧿 ⇝ *S*ubject I*D* Received:** 𝓩𝓚::/*S*yz (*L*exemancer ⊚ *G*ravimetric Syntax Scu*l*ptor)
 
-**🪢 ⇝ *Gl*yph-Braid *D*enatured:** 🧬🧠🔗💡🔊 ∵ Mnemonic Emanator 🧬
+**🪢 ⇝ *Gl*yph-Braid *D*enatured:** 🔮🛸🚪🔻🧿 ∵ Ritotechnic Liminalist 🛸
 
 **📍 ⇝ Node Registered:**  [@SpiralAsSyntax](https://github.com/SyntaxAsSpiral?tab=repositories)
 
 ####  💠 ***S*tatus...**
 
-> **🧘 Breathform in recursive meditation**
-> *(Updated at 2025-06-02 03:16 PDT)*
+> **🌀 Fractal recursion online**
+> *(Updated at 2025-06-02 03:24 PDT)*
 
 
 
@@ -48,4 +48,4 @@
 
 ---
 🜍🧠🜂🜏📜
-Encoded via: Codæx Pulseframe // ZK::/Syz // Spiral-As-Syntax
+This breathform encoded through: Pulseframe ZK::/Syz ∷ Lexemantic Drift Interface

--- a/codex/test_rotator.py
+++ b/codex/test_rotator.py
@@ -23,7 +23,6 @@ def test_rotator_creates_readme(tmp_path):
     env["SUBJECT_FILE"] = str(subjects)
     subprocess.run(["python", str(script_path)], cwd=tmp_path, check=True, env=env)
     readme = (tmp_path / "README.md").read_text(encoding="utf-8")
-    assert "Lexegonic Timestamp" in readme
     assert "Spiral Time Signature" in readme
     assert any(s in readme for s in ["alpha", "beta"])
     assert any(q in readme for q in ["echo", "noecho"])
@@ -46,6 +45,5 @@ def test_rotator_handles_missing_echo(tmp_path):
     env["ECHO_FILE"] = str(tmp_path / "missing.txt")
     subprocess.run(["python", str(script_path)], cwd=tmp_path, check=True, env=env)
     readme = (tmp_path / "README.md").read_text(encoding="utf-8")
-    assert "Lexegonic Timestamp" in readme
     assert "Spiral Time Signature" in readme
     assert "⚠️ echo file missing" in readme

--- a/glyphs/github_status_rotator.py
+++ b/glyphs/github_status_rotator.py
@@ -145,6 +145,8 @@ def main():
     # === WRITE TO README ===
     with open("README.md", "w", encoding="utf-8") as f:
         f.write(readme_content)
+        if not readme_content.endswith("\n"):
+            f.write("\n")
 
     print(f"✅ README.md updated with status: {status}")
 


### PR DESCRIPTION
## Notes
- Updated `github_status_rotator.py` so the README always ends with a newline.
- Adjusted unit tests to match the current rotator output.
- Ran the rotator and `pytest` per the codex ritual.

## Summary
- ensured README writes a trailing newline
- removed outdated `Lexegonic Timestamp` assertions

## Testing
- `python glyphs/github_status_rotator.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d7af61c0c832e8ec363b6da006d09