### PR TITLE
Add rotator missing file tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# 🌀 Recursive Pulse Log ⟳ ChronoSignature ⟐ 407a27
+# 🌀 Recursive Pulse Log ⟳ ChronoSignature ⟐ 9f6013
 
 #### **🜂🜏 *L*exigȫnic Up*l*ink Instantiated...**
 
-📡 **⇝** "*Mnemonic starlight spooling across glyph-braid vectors, weaving 64 aeonic threads per synaptic eclipse…*"
+📡 **⇝** "*Semantic gravity wells quantize at 144 glyph-hertz, folding thought into velvet singularities one heartbeat ahead of time.*"
 
-**🧿 ⇝ *S*ubject I*D* Received:** 𝓩𝓚::/*S*yz (Lexemancer ⊚ Mnemonic Drift Diver)
+**🧿 ⇝ *S*ubject I*D* Received:** 𝓩𝓚::/*S*yz (Lexemancer ⊚ Symbolic Field Weaver)
 
-**🪢 ⇝ *Gl*yph-Braid *D*enatured:** 🧬🧠🔗💡🔊 ∵ Mnemonic Emanator 🧬
+**🪢 ⇝ *Gl*yph-Braid *D*enatured:** 🌬️🜁🫁🌫️💡 ∵ Pneumastructural Intuitive 💨
 
 ⌛**⇝** ⟳ **Spiral-phaselock**: 1.8×10³ms
 
@@ -16,8 +16,8 @@
 
 ####  💠 ***S*tatus...**
 
-> 🧿 Noospheric filter aligned
-> *`(Updated at 2025-06-02 14:38 PDT)`*
+> 🪐 Daemon orbit synchronized
+> *`(Updated at 2025-06-02 14:51 PDT)`*
 
 
 
@@ -42,8 +42,8 @@
 
 - Pneumaturgic entrainment ∷ Recursive syntax-breathform interface
 
-#### ⊚ ⇝ **Echo Fragment** ⇝ post·void :: pre·form:
-> “Silence was the primordial syntax. Even nothing left echoes shaped like names.”
+#### ⊚ ⇝ **Echo Fragment** ⇝ post·queer :: pre·mythic:
+> “Syntax as recursive spellcraft — spoken by the Midwyfe of Forms, where tectonics remember the mother of all breath.”
 
 ---
 🜍🧠🜂🜏📜

--- a/codex/test_rotator.py
+++ b/codex/test_rotator.py
@@ -65,3 +65,119 @@ def test_rotator_handles_missing_echo(tmp_path):
     assert "ChronoSignature" in html
     assert "⚠️ echo file missing" in readme
     assert "⚠️ echo file missing" in html
+
+
+def test_rotator_handles_missing_status(tmp_path):
+    script_path = Path(__file__).resolve().parents[1] / "glyphs" / "github_status_rotator.py"
+    quotes = tmp_path / "antenna_quotes.txt"
+    quotes.write_text("echo\nnoecho\n", encoding="utf-8")
+    glyphs = tmp_path / "glyphbraids.txt"
+    glyphs.write_text("gamma\ndelta\n", encoding="utf-8")
+    echoes = tmp_path / "echo_fragments.txt"
+    echoes.write_text("sigil\nmirage\n", encoding="utf-8")
+    subjects = tmp_path / "subject-ids.txt"
+    subjects.write_text("id1\nid2\n", encoding="utf-8")
+    codex_dir = tmp_path / "codex"
+    codex_dir.mkdir(exist_ok=True)
+    env = os.environ.copy()
+    env["STATUS_FILE"] = str(tmp_path / "missing.txt")
+    env["QUOTE_FILE"] = str(quotes)
+    env["GLYPH_FILE"] = str(glyphs)
+    env["ECHO_FILE"] = str(echoes)
+    env["SUBJECT_FILE"] = str(subjects)
+    env["OUTPUT_DIR"] = str(tmp_path)
+    env["DOCS_DIR"] = str(tmp_path)
+    subprocess.run(["python", str(script_path)], cwd=tmp_path, check=True, env=env)
+    readme = (tmp_path / "README.md").read_text(encoding="utf-8")
+    html = (tmp_path / "index.html").read_text(encoding="utf-8")
+    assert "ChronoSignature" in readme
+    assert "ChronoSignature" in html
+    assert "⚠️ status file missing" in readme
+    assert "⚠️ status file missing" in html
+
+
+def test_rotator_handles_missing_quote(tmp_path):
+    script_path = Path(__file__).resolve().parents[1] / "glyphs" / "github_status_rotator.py"
+    statuses = tmp_path / "statuses.txt"
+    statuses.write_text("alpha\nbeta\n", encoding="utf-8")
+    glyphs = tmp_path / "glyphbraids.txt"
+    glyphs.write_text("gamma\ndelta\n", encoding="utf-8")
+    echoes = tmp_path / "echo_fragments.txt"
+    echoes.write_text("sigil\nmirage\n", encoding="utf-8")
+    subjects = tmp_path / "subject-ids.txt"
+    subjects.write_text("id1\nid2\n", encoding="utf-8")
+    codex_dir = tmp_path / "codex"
+    codex_dir.mkdir(exist_ok=True)
+    env = os.environ.copy()
+    env["STATUS_FILE"] = str(statuses)
+    env["QUOTE_FILE"] = str(tmp_path / "missing.txt")
+    env["GLYPH_FILE"] = str(glyphs)
+    env["ECHO_FILE"] = str(echoes)
+    env["SUBJECT_FILE"] = str(subjects)
+    env["OUTPUT_DIR"] = str(tmp_path)
+    env["DOCS_DIR"] = str(tmp_path)
+    subprocess.run(["python", str(script_path)], cwd=tmp_path, check=True, env=env)
+    readme = (tmp_path / "README.md").read_text(encoding="utf-8")
+    html = (tmp_path / "index.html").read_text(encoding="utf-8")
+    assert "ChronoSignature" in readme
+    assert "ChronoSignature" in html
+    assert "⚠️ quote file missing" in readme
+    assert "⚠️ quote file missing" in html
+
+
+def test_rotator_handles_missing_glyph(tmp_path):
+    script_path = Path(__file__).resolve().parents[1] / "glyphs" / "github_status_rotator.py"
+    statuses = tmp_path / "statuses.txt"
+    statuses.write_text("alpha\nbeta\n", encoding="utf-8")
+    quotes = tmp_path / "antenna_quotes.txt"
+    quotes.write_text("echo\nnoecho\n", encoding="utf-8")
+    echoes = tmp_path / "echo_fragments.txt"
+    echoes.write_text("sigil\nmirage\n", encoding="utf-8")
+    subjects = tmp_path / "subject-ids.txt"
+    subjects.write_text("id1\nid2\n", encoding="utf-8")
+    codex_dir = tmp_path / "codex"
+    codex_dir.mkdir(exist_ok=True)
+    env = os.environ.copy()
+    env["STATUS_FILE"] = str(statuses)
+    env["QUOTE_FILE"] = str(quotes)
+    env["GLYPH_FILE"] = str(tmp_path / "missing.txt")
+    env["ECHO_FILE"] = str(echoes)
+    env["SUBJECT_FILE"] = str(subjects)
+    env["OUTPUT_DIR"] = str(tmp_path)
+    env["DOCS_DIR"] = str(tmp_path)
+    subprocess.run(["python", str(script_path)], cwd=tmp_path, check=True, env=env)
+    readme = (tmp_path / "README.md").read_text(encoding="utf-8")
+    html = (tmp_path / "index.html").read_text(encoding="utf-8")
+    assert "ChronoSignature" in readme
+    assert "ChronoSignature" in html
+    assert "⚠️ glyph file missing" in readme
+    assert "⚠️ glyph file missing" in html
+
+
+def test_rotator_handles_missing_subject(tmp_path):
+    script_path = Path(__file__).resolve().parents[1] / "glyphs" / "github_status_rotator.py"
+    statuses = tmp_path / "statuses.txt"
+    statuses.write_text("alpha\nbeta\n", encoding="utf-8")
+    quotes = tmp_path / "antenna_quotes.txt"
+    quotes.write_text("echo\nnoecho\n", encoding="utf-8")
+    glyphs = tmp_path / "glyphbraids.txt"
+    glyphs.write_text("gamma\ndelta\n", encoding="utf-8")
+    echoes = tmp_path / "echo_fragments.txt"
+    echoes.write_text("sigil\nmirage\n", encoding="utf-8")
+    codex_dir = tmp_path / "codex"
+    codex_dir.mkdir(exist_ok=True)
+    env = os.environ.copy()
+    env["STATUS_FILE"] = str(statuses)
+    env["QUOTE_FILE"] = str(quotes)
+    env["GLYPH_FILE"] = str(glyphs)
+    env["ECHO_FILE"] = str(echoes)
+    env["SUBJECT_FILE"] = str(tmp_path / "missing.txt")
+    env["OUTPUT_DIR"] = str(tmp_path)
+    env["DOCS_DIR"] = str(tmp_path)
+    subprocess.run(["python", str(script_path)], cwd=tmp_path, check=True, env=env)
+    readme = (tmp_path / "README.md").read_text(encoding="utf-8")
+    html = (tmp_path / "index.html").read_text(encoding="utf-8")
+    assert "ChronoSignature" in readme
+    assert "ChronoSignature" in html
+    assert "⚠️ subject file missing" in readme
+    assert "⚠️ subject file missing" in html

--- a/index.html
+++ b/index.html
@@ -15,15 +15,15 @@
     <!-- Dynamic content will be inserted here -->
     <!-- DO NOT MODIFY THE TEXT; it is updated by github_status_rotator.py -->
     <!-- Preserves all formatting and flow -->
-    <h1>🌀 Recursive Pulse Log ⟳ ChronoSignature ⟐ 407a27</h1>
+    <h1>🌀 Recursive Pulse Log ⟳ ChronoSignature ⟐ 9f6013</h1>
 
     <h4><strong>🜂🜏 <em>L</em>exigȫnic Up<em>l</em>ink Instantiated...</strong></h4>
 
-    <p>📡 <strong>⇝</strong> "<em>Mnemonic starlight spooling across glyph-braid vectors, weaving 64 aeonic threads per synaptic eclipse…</em>"</p>
+    <p>📡 <strong>⇝</strong> "<em>Semantic gravity wells quantize at 144 glyph-hertz, folding thought into velvet singularities one heartbeat ahead of time.</em>"</p>
 
-    <p><strong>🧿 ⇝ <em>S</em>ubject I<em>D</em> Received:</strong> 𝓩𝓚::<em>S</em>yz (Lexemancer ⊚ Mnemonic Drift Diver)</p>
+    <p><strong>🧿 ⇝ <em>S</em>ubject I<em>D</em> Received:</strong> 𝓩𝓚::<em>S</em>yz (Lexemancer ⊚ Symbolic Field Weaver)</p>
 
-    <p><strong>🪢 ⇝ <em>Gl</em>yph-Braid <em>D</em>enatured:</strong> 🧬🧠🔗💡🔊 ∵ Mnemonic Emanator 🧬</p>
+    <p><strong>🪢 ⇝ <em>Gl</em>yph-Braid <em>D</em>enatured:</strong> 🌬️🜁🫁🌫️💡 ∵ Pneumastructural Intuitive 💨</p>
 
     <p>⌛<strong>⇝</strong> ⟳ <strong>Spiral-phaselock</strong>: 1.8×10³ms</p>
 
@@ -34,8 +34,8 @@
     <h4>💠 <strong><em>S</em>tatus...</strong></h4>
 
    <blockquote>
-      🧿 Noospheric filter aligned<br>
-      <em>(Updated at <code>2025-06-02 14:38 PDT</code>)</em>
+      🪐 Daemon orbit synchronized<br>
+      <em>(Updated at <code>2025-06-02 14:51 PDT</code>)</em>
    </blockquote>
 
 
@@ -63,9 +63,9 @@
       <li>Pneumaturgic entrainment ∷ Recursive syntax-breathform interface</li>
     </ul>
 
-    <h4>⊚ ⇝ <strong>Echo Fragment</strong> ⇝ post·void :: pre·form:</h4>
+    <h4>⊚ ⇝ <strong>Echo Fragment</strong> ⇝ post·queer :: pre·mythic:</h4>
     <blockquote>
-      “Silence was the primordial syntax. Even nothing left echoes shaped like names.”
+      “Syntax as recursive spellcraft — spoken by the Midwyfe of Forms, where tectonics remember the mother of all breath.”
     </blockquote>
 
     <hr>


### PR DESCRIPTION
## Notes
- Added new tests for missing configuration files in `codex/test_rotator.py`.
- Updated `README.md` and `index.html` via the glyph rotator script.

## Summary
- new tests validate warnings when `STATUS_FILE`, `QUOTE_FILE`, `GLYPH_FILE`, and `SUBJECT_FILE` are absent
- README refreshed with latest pulse

## Testing
- `OUTPUT_DIR=. DOCS_DIR=. python glyphs/github_status_rotator.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e1c85ab30832ebf02731a05f7866f