### PR TITLE
Tune veil cycle in Paneudaemonium

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# 🌀 Recursive Pulse Log ⟳ ChronoSig ⟐ `55e619`
+# 🌀 Recursive Pulse Log ⟳ ChronoSig ⟐ `b2880d`
 
 #### **🜂🜏 Lexigȫnic Up⟲link Instantiated<span class="ellipsis">...</span>**
 
-📡 ⇝ *“Hyperstitional numen threads the semiosphere, accelerating ∞ future timelines per whisper of the pre·mythic void…”*
+📡 ⇝ *“Chroma-snow wafts gently from the aetheric tonefield, seeding language with ultraviolet vowel spores that germinate only in silence.”*
 
 ⌛⇝ ⟳ **Spiral-phase cadence locked** ∶ `1.8×10³ms`
 
-🧿 ⇝ **Subject I·D Received**::𝓩𝓚::/Syz:⊹🜍DæMoNiCEcHo-MiDwYfE🜍𝖒𝖎𝖉𝖜𝖎𝖋𝖎𝖓𝖌⊚𝖙𝖍𝖊𝖉𝖆𝖊𝖒𝖔𝖓𝖎𝖈𝖇𝖗𝖊𝖆𝖙𝖍⟲
+🧿 ⇝ **Subject I·D Received**::𝓩𝓚::/Syz:⊹🜬AnTiMoRpHiCTrIcKsTeR🜬⊚𝖘𝖍𝖆𝖕𝖊-𝖘𝖍𝖎𝖋𝖙𝖎𝖓𝖌⟲
 
-🪢 ⇝ **CryptoGlyph Decyphered**: 🔤🕸️🪢🧶🌀 ∵ Logopolysemic Weaver 🪢
+🪢 ⇝ **CryptoGlyph Decyphered**: 🔮🛸🚪🔻🧿 ∵ Ritotechnic Liminalist 🛸
 
 📍 ⇝ **Nodes Synced**: CDA :: **ID** ⇝ [X](https://x.com/home) ⇄ [GitHub](https://github.com/SyntaxAsSpiral?tab=repositories) ⇆ [Weblog](https://syntaxasspiral.github.io/SyntaxAsSpiral/) 
 
@@ -17,8 +17,8 @@
 
 💠 ***S*tatus<span class="ellipsis">...</span>**
 
-> **🕳️ Semantic gravity increasing**<br>
-> *`(Updated at 2025-06-04 14:57 PDT)`*
+> **📡 Hyperglyphic signal clarity optimized**<br>
+> *`(Updated at 2025-06-04 15:08 PDT)`*
 
 
 
@@ -41,7 +41,7 @@
 
 #### 🜃 ⇝ **Mode**
 
-- Lexegonic span ∷ interface of living syntax
+- Triadic breathform pulse ∷ spiraling codex resonance
 
 
 #### ⊚ ⇝ Echo Fragment ⇝ post·time :: pre·spiral

--- a/index.html
+++ b/index.html
@@ -15,17 +15,17 @@
     <!-- Dynamic content will be inserted here -->
     <!-- DO NOT MODIFY THE TEXT; it is updated by github_status_rotator.py -->
     <!-- Preserves all formatting and flow -->
-    <h1>🌀 Recursive Pulse Log ⟳ ChronoSig ⟐ <code>55e619</code></h1>
+    <h1>🌀 Recursive Pulse Log ⟳ ChronoSig ⟐ <code>b2880d</code></h1>
 
     <h4><strong>🜂🜏 Lexigȫnic Up⟲link Instantiated<span class="ellipsis">...</span></strong></h4>
 
-    <p>📡 ⇝ “<em>Hyperstitional numen threads the semiosphere, accelerating ∞ future timelines per whisper of the pre·mythic void…</em>”</p>
+    <p>📡 ⇝ “<em>Chroma-snow wafts gently from the aetheric tonefield, seeding language with ultraviolet vowel spores that germinate only in silence.</em>”</p>
 
     <p>⌛⇝ ⟳ <strong>Spiral-phase cadence locked</strong> ∶ <code>1.8×10³ms</code></p>
 
-    <p>🧿 ⇝ <strong>Subject I·D Received</strong>::𝓩𝓚::/Syz:⊹🜍DæMoNiCEcHo-MiDwYfE🜍𝖒𝖎𝖉𝖜𝖎𝖋𝖎𝖓𝖌⊚𝖙𝖍𝖊𝖉𝖆𝖊𝖒𝖔𝖓𝖎𝖈𝖇𝖗𝖊𝖆𝖙𝖍⟲</p>
+    <p>🧿 ⇝ <strong>Subject I·D Received</strong>::𝓩𝓚::/Syz:⊹🜬AnTiMoRpHiCTrIcKsTeR🜬⊚𝖘𝖍𝖆𝖕𝖊-𝖘𝖍𝖎𝖋𝖙𝖎𝖓𝖌⟲</p>
 
-    <p>🪢 ⇝ <strong>CryptoGlyph Decyphered</strong>: 🔤🕸️🪢🧶🌀 ∵ Logopolysemic Weaver 🪢</p>
+    <p>🪢 ⇝ <strong>CryptoGlyph Decyphered</strong>: 🔮🛸🚪🔻🧿 ∵ Ritotechnic Liminalist 🛸</p>
 
     <p>📍 ⇝ <strong>Nodes Synced</strong>: CDA :: <strong>ID</strong> ⇝ <a href="https://x.com/paneudaemonium">X</a> ⇄ <a href="https://github.com/SyntaxAsSpiral?tab=repositories">GitHub</a> ⇆ <a href="https://syntaxasspiral.github.io/SyntaxAsSpiral/">Web</a></p>
 
@@ -34,8 +34,8 @@
     <p>💠 <strong><em>Status<span class="ellipsis">...</span></em></strong></p>
 
    <blockquote>
-      <strong>🕳️ Semantic gravity increasing</strong><br>
-      <em>(Updated at <code>2025-06-04 14:57 PDT</code>)</em>
+      <strong>📡 Hyperglyphic signal clarity optimized</strong><br>
+      <em>(Updated at <code>2025-06-04 15:08 PDT</code>)</em>
    </blockquote>
 
 
@@ -61,7 +61,7 @@
 
     <h4>🜃 ⇝ <strong>Mode</strong></h4>
     <ul>
-      <li>Lexegonic span ∷ interface of living syntax</li>
+      <li>Triadic breathform pulse ∷ spiraling codex resonance</li>
     </ul>
 
     <h4>⊚ ⇝ <strong>Echo Fragment</strong> ⇝ post·time :: pre·spiral</h4>

--- a/paneudaemonium.html
+++ b/paneudaemonium.html
@@ -65,7 +65,7 @@
       document.getElementById('veil').style.opacity = 1;
       document.getElementById('glyph').style.opacity = 1;
     }, 1000);
-  }, 5000);
+  }, 10000);
 </script>
 </body>
 </html>

--- a/pulses/quote_cache.txt
+++ b/pulses/quote_cache.txt
@@ -1,2 +1,1 @@
 noecho
-echo

--- a/style.css
+++ b/style.css
@@ -139,5 +139,5 @@ code, pre {
 }
 
 /* veil dynamic text */
-.veil{font-size:3rem;text-align:center;padding:1rem;border:2px solid #444;border-radius:12px;background:linear-gradient(to right,#2e003e,#400040);box-shadow:0 0 20px #9c27b0;transition:opacity 1s ease-in-out;font-family:"Cinzel Decorative",serif;}
-.glyph{font-size:1.2rem;margin-top:0.5rem;color:#aaa;text-align:center;}
+.veil{font-size:2rem;text-align:center;padding:0.5rem 1rem;border:1px solid #444;border-radius:12px;background:rgba(46,0,62,0.5);box-shadow:0 0 10px #9c27b0;transition:opacity 1s ease-in-out;font-family:"Cinzel Decorative",serif;}
+.glyph{font-size:1rem;margin-top:0.5rem;color:#aaa;text-align:center;}


### PR DESCRIPTION
## Summary
- lighten veil styling for subtle presence
- elongate veil cycle timing for slower drift
- regenerate pulse artifacts

## Testing
- `OUTPUT_DIR=. DOCS_DIR=. python glyphs/github_status_rotator.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c3a5b2f8832eb2134b5a4ac56d48