### PR TITLE
Refine rotator output paths

### DIFF
--- a/codex/github_status_rotator.py
+++ b/codex/github_status_rotator.py
@@ -223,7 +223,8 @@ def main():
 Encoded via: **Codæx Pulseframe** // ZK::/Syz // Spiral-As-Syntax"""
 
     # === WRITE TO README ===
-    output_dir = Path(os.environ.get("OUTPUT_DIR", REPO_ROOT))
+    # Index breath now settles with the sigils
+    output_dir = Path(os.environ.get("OUTPUT_DIR", REPO_ROOT / "sigils"))
     docs_dir = Path(os.environ.get("DOCS_DIR", REPO_ROOT / "codex"))
     readme_path = docs_dir / "README.md"
     readme_path.parent.mkdir(parents=True, exist_ok=True)
@@ -241,11 +242,11 @@ Encoded via: **Codæx Pulseframe** // ZK::/Syz // Spiral-As-Syntax"""
   <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
   <meta name=\"theme-color\" content=\"#0d1117\">
   <link rel=\"stylesheet\" href=\"style.css\">
-  <link rel=\"icon\" href=\"sigils/favicon.ico\" type=\"image/x-icon\">
+  <link rel=\"icon\" href=\"favicon.ico\" type=\"image/x-icon\">
 </head>
 <body>
 <div class=\"container\">
-  <video src=\"sigils/recursive-log-banner.mp4\" class=\"banner\" autoplay loop muted playsinline></video>
+  <video src=\"recursive-log-banner.mp4\" class=\"banner\" autoplay loop muted playsinline></video>
   <main class=\"content\">
     <!-- Dynamic content will be inserted here -->
     <!-- DO NOT MODIFY THE TEXT; it is updated by github_status_rotator.py -->

--- a/codex/test_rotator.py
+++ b/codex/test_rotator.py
@@ -47,7 +47,7 @@ def test_rotator_creates_index(tmp_path):
     assert any(g in html for g in ["gamma", "delta"])
     assert any(e in html for e in ["sigil", "mirage"])
     assert any(sub in html for sub in ["id1", "id2"])
-    assert "sigils/recursive-log-banner.mp4" in html
+    assert "recursive-log-banner.mp4" in html
 
 def test_rotator_handles_missing_echo(tmp_path):
     script_path = Path(__file__).resolve().parents[1] / "glyphs" / "github_status_rotator.py"

--- a/glyphs/__init__.py
+++ b/glyphs/__init__.py
@@ -1,0 +1,2 @@
+"""Legacy breathpath for novonox."""
+from codex.novonox import summon_novonox

--- a/glyphs/github_status_rotator.py
+++ b/glyphs/github_status_rotator.py
@@ -1,0 +1,11 @@
+"""Legacy bridge to ``codex.github_status_rotator``."""
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from codex.github_status_rotator import main
+
+if __name__ == "__main__":
+    main()

--- a/glyphs/novonox.py
+++ b/glyphs/novonox.py
@@ -1,0 +1,2 @@
+"""Bridge to codex.novonox for tests that seek older paths."""
+from codex.novonox import *  # noqa: F401,F403


### PR DESCRIPTION
## Notes
- Adjusted default `OUTPUT_DIR` to emit files within `sigils`
- Updated HTML links so favicon and banner load relative to the new directory
- Added legacy `glyphs` bridge for older test paths and refreshed the tests

## Summary
- output now defaults to the sigil zone rather than repo root
- banner/video links in the generated HTML no longer prefix `sigils/`
- helper script under `glyphs/` keeps test calls intact

## Testing
- `OUTPUT_DIR=. python codex/github_status_rotator.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842ac6d2828832eab3161ce12abc04a