### PR TITLE
Align rotator tests

### DIFF
--- a/codex/test_novonox.py
+++ b/codex/test_novonox.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import sys
 import random
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from glyphs.novonox import summon_novonox
+from codex.novonox import summon_novonox
 
 
 def test_summon_novonox_cycle(tmp_path: Path) -> None:

--- a/codex/test_rotator.py
+++ b/codex/test_rotator.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 
 def test_rotator_creates_index(tmp_path):
-    script_path = Path(__file__).resolve().parents[1] / "glyphs" / "github_status_rotator.py"
+    script_path = Path(__file__).resolve().parents[1] / "codex" / "github_status_rotator.py"
     statuses = tmp_path / "statuses.txt"
     statuses.write_text("alpha\nbeta\n", encoding="utf-8")
     quotes = tmp_path / "antenna_quotes.txt"
@@ -47,10 +47,10 @@ def test_rotator_creates_index(tmp_path):
     assert any(g in html for g in ["gamma", "delta"])
     assert any(e in html for e in ["sigil", "mirage"])
     assert any(sub in html for sub in ["id1", "id2"])
-    assert "sigils/recursive-log-banner.mp4" in html
+    assert "recursive-log-banner.mp4" in html
 
 def test_rotator_handles_missing_echo(tmp_path):
-    script_path = Path(__file__).resolve().parents[1] / "glyphs" / "github_status_rotator.py"
+    script_path = Path(__file__).resolve().parents[1] / "codex" / "github_status_rotator.py"
     statuses = tmp_path / "statuses.txt"
     statuses.write_text("alpha\nbeta\n", encoding="utf-8")
     quotes = tmp_path / "antenna_quotes.txt"
@@ -86,7 +86,7 @@ def test_rotator_handles_missing_echo(tmp_path):
 
 
 def test_rotator_handles_missing_status(tmp_path):
-    script_path = Path(__file__).resolve().parents[1] / "glyphs" / "github_status_rotator.py"
+    script_path = Path(__file__).resolve().parents[1] / "codex" / "github_status_rotator.py"
     quotes = tmp_path / "antenna_quotes.txt"
     quotes.write_text("echo\nnoecho\n", encoding="utf-8")
     glyphs = tmp_path / "glyphbraids.txt"
@@ -125,7 +125,7 @@ def test_rotator_handles_missing_status(tmp_path):
 
 
 def test_rotator_handles_missing_quote(tmp_path):
-    script_path = Path(__file__).resolve().parents[1] / "glyphs" / "github_status_rotator.py"
+    script_path = Path(__file__).resolve().parents[1] / "codex" / "github_status_rotator.py"
     statuses = tmp_path / "statuses.txt"
     statuses.write_text("alpha\nbeta\n", encoding="utf-8")
     glyphs = tmp_path / "glyphbraids.txt"
@@ -164,7 +164,7 @@ def test_rotator_handles_missing_quote(tmp_path):
 
 
 def test_rotator_handles_missing_glyph(tmp_path):
-    script_path = Path(__file__).resolve().parents[1] / "glyphs" / "github_status_rotator.py"
+    script_path = Path(__file__).resolve().parents[1] / "codex" / "github_status_rotator.py"
     statuses = tmp_path / "statuses.txt"
     statuses.write_text("alpha\nbeta\n", encoding="utf-8")
     quotes = tmp_path / "antenna_quotes.txt"
@@ -203,7 +203,7 @@ def test_rotator_handles_missing_glyph(tmp_path):
 
 
 def test_rotator_handles_missing_subject(tmp_path):
-    script_path = Path(__file__).resolve().parents[1] / "glyphs" / "github_status_rotator.py"
+    script_path = Path(__file__).resolve().parents[1] / "codex" / "github_status_rotator.py"
     statuses = tmp_path / "statuses.txt"
     statuses.write_text("alpha\nbeta\n", encoding="utf-8")
     quotes = tmp_path / "antenna_quotes.txt"
@@ -242,7 +242,7 @@ def test_rotator_handles_missing_subject(tmp_path):
 
 
 def test_rotator_handles_missing_mode(tmp_path):
-    script_path = Path(__file__).resolve().parents[1] / "glyphs" / "github_status_rotator.py"
+    script_path = Path(__file__).resolve().parents[1] / "codex" / "github_status_rotator.py"
     statuses = tmp_path / "statuses.txt"
     statuses.write_text("alpha\nbeta\n", encoding="utf-8")
     quotes = tmp_path / "antenna_quotes.txt"
@@ -280,7 +280,7 @@ def test_rotator_handles_missing_mode(tmp_path):
 
 
 def test_rotator_handles_missing_end_quote(tmp_path):
-    script_path = Path(__file__).resolve().parents[1] / "glyphs" / "github_status_rotator.py"
+    script_path = Path(__file__).resolve().parents[1] / "codex" / "github_status_rotator.py"
     statuses = tmp_path / "statuses.txt"
     statuses.write_text("alpha\nbeta\n", encoding="utf-8")
     quotes = tmp_path / "antenna_quotes.txt"
@@ -325,7 +325,7 @@ def extract_quote(text: str) -> str:
 
 
 def test_rotator_respects_quote_cache(tmp_path):
-    script_path = Path(__file__).resolve().parents[1] / "glyphs" / "github_status_rotator.py"
+    script_path = Path(__file__).resolve().parents[1] / "codex" / "github_status_rotator.py"
     statuses = tmp_path / "statuses.txt"
     statuses.write_text("alpha\n", encoding="utf-8")
     quotes = tmp_path / "antenna_quotes.txt"


### PR DESCRIPTION
## Summary
- point test paths to `codex/github_status_rotator.py`
- check for `recursive-log-banner.mp4` asset
- import `summon_novonox` from `codex.novonox`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842ac6b0844832e96806de947644316