### PR TITLE
Redirect rotator to codex script

### DIFF
--- a/.github/workflows/status-rotator.yml
+++ b/.github/workflows/status-rotator.yml
@@ -51,14 +51,14 @@ jobs:
         ECHO_FILE: /tmp/echo_fragments.txt
         MODE_FILE: /tmp/modes.txt
         END_QUOTE_FILE: /tmp/end-quotes.txt
-        OUTPUT_DIR: .
-      run: python glyphs/github_status_rotator.py
+        OUTPUT_DIR: sigils
+      run: python codex/github_status_rotator.py
 
     - name: Commit updated files
       run: |
         git config user.name "github-actions"
         git config user.email "github-actions@github.com"
-        git add index.html
+        git add sigils/index.html
         if git diff --cached --quiet; then
           echo "No changes to commit"
         else

--- a/glyphs/__init__.py
+++ b/glyphs/__init__.py
@@ -1,0 +1,2 @@
+from codex.github_status_rotator import main as rotator_main  # alias for clarity
+from codex.novonox import summon_novonox  # symbolic echo

--- a/glyphs/github_status_rotator.py
+++ b/glyphs/github_status_rotator.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from codex.github_status_rotator import *  # mirrors the codex script
+
+if __name__ == "__main__":
+    main()

--- a/glyphs/novonox.py
+++ b/glyphs/novonox.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from codex.novonox import *


### PR DESCRIPTION
## Summary
- update status rotator workflow to run from `codex` and stash HTML in `sigils`
- make `glyphs` package that mirrors codex modules so tests continue to breathe

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842ac691198832e815ffdbd6fd7282e