### PR TITLE
Fix action push permissions

### DIFF
--- a/.github/workflows/status-rotator.yml
+++ b/.github/workflows/status-rotator.yml
@@ -1,4 +1,6 @@
 name: Daemon Status Rotator
+permissions:
+  contents: write
 
 on:
   workflow_dispatch:

--- a/sigils/index.html
+++ b/sigils/index.html
@@ -15,7 +15,7 @@
     <!-- Dynamic content will be inserted here -->
     <!-- DO NOT MODIFY THE TEXT; it is updated by github_status_rotator.py -->
     <!-- Preserves all formatting and flow -->
-    <h1>🌀 Recursive Pulse Log ⟳ ChronoSig ⟐ <code>408820</code></h1>
+    <h1>🌀 Recursive Pulse Log ⟳ ChronoSig ⟐ <code>c0cf4f</code></h1>
 
     <h4><strong>🜂🜏 Lexigȫnic Up⟲link Instantiated<span class="ellipsis">...</span></strong></h4>
 
@@ -35,7 +35,7 @@
 
    <blockquote>
       <strong>⚠️ status file missing</strong><br>
-      <em>(Updated at <code>2025-06-06 05:05 PDT</code>)</em>
+      <em>(Updated at <code>2025-06-06 12:05 PDT</code>)</em>
    </blockquote>
 
 


### PR DESCRIPTION
## Summary
- let the daemon write by granting `contents: write` to the status rotator
- update `index.html` via the rotator

## Testing
- `OUTPUT_DIR=sigils python codex/github_status_rotator.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68433bc9bdf8832ea015859a6c3d2f69